### PR TITLE
fix: preserve guild id if present when sending

### DIFF
--- a/src/bot/message.ts
+++ b/src/bot/message.ts
@@ -28,7 +28,7 @@ export class OneBotMessageEncoder<C extends Context = Context> extends MessageEn
         ? Universal.Channel.Type.DIRECT
         : Universal.Channel.Type.TEXT
     }
-    if (!this.session.isDirect) this.guildId = this.channelId
+    if (!this.guildId && !this.session.isDirect) this.guildId = this.channelId
   }
 
   async forward() {


### PR DESCRIPTION
不太清楚除了 qq 私聊之外什么情况下需要用频道 id 覆盖群组 id，但至少这样改了之后能在 qq 频道发消息了（通过 go-cqhttp）