### PR TITLE
新增逻辑判断：当消息事件包含raw参数时获取raw参数内的msgId

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -71,7 +71,7 @@ export interface Message extends MessageId {
   guild_id?: string
   channel_id?: string
   message: string | CQCode[]
-  anonymous?: AnonymousInfo,
+  anonymous?: AnonymousInfo
   raw?: RawMessage
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,7 +76,7 @@ export interface Message extends MessageId {
 }
 
 export interface RawMessage {
-    msgId: string
+  msgId: string
 }
 
 export interface AnonymousInfo {

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,7 +71,12 @@ export interface Message extends MessageId {
   guild_id?: string
   channel_id?: string
   message: string | CQCode[]
-  anonymous?: AnonymousInfo
+  anonymous?: AnonymousInfo,
+  raw?: RawMessage
+}
+
+export interface RawMessage {
+    msgId: string
 }
 
 export interface AnonymousInfo {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,9 +45,8 @@ export async function adaptMessage(
   message: Universal.Message = {},
   payload: Universal.MessageLike = message,
 ) {
-//   message.id = message.messageId = data.message_id.toString()
-  message.id = message.messageId = "raw" in data ? data.raw.msgId : data.message_id.toString();
-
+//   message.id = message.messageId = data.message_id.toString() // 原方法
+  message.id = message.messageId = "raw" in data ? data.raw.msgId : data.message_id.toString(); // 检测是否包含 raw 参数以获取正确的 msgId
 
   // message content
   const chain = CQCode.parse(data.message)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,7 +46,6 @@ export async function adaptMessage(
   payload: Universal.MessageLike = message,
 ) {
 //   message.id = message.messageId = data.message_id.toString()
-  bot.logger.info("[Debug] fixed");
   message.id = message.messageId = "raw" in data ? data.raw.msgId : data.message_id.toString();
 
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,7 +45,10 @@ export async function adaptMessage(
   message: Universal.Message = {},
   payload: Universal.MessageLike = message,
 ) {
-  message.id = message.messageId = data.message_id.toString()
+//   message.id = message.messageId = data.message_id.toString()
+  bot.logger.info("[Debug] fixed");
+  message.id = message.messageId = "raw" in data ? data.raw.msgId : data.message_id.toString();
+
 
   // message content
   const chain = CQCode.parse(data.message)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,8 +45,9 @@ export async function adaptMessage(
   message: Universal.Message = {},
   payload: Universal.MessageLike = message,
 ) {
-//   message.id = message.messageId = data.message_id.toString() // 原方法
-  message.id = message.messageId = "raw" in data ? data.raw.msgId : data.message_id.toString(); // 检测是否包含 raw 参数以获取正确的 msgId
+  // https://github.com/LLOneBot/LLOneBot/issues/269
+  // message.id = message.messageId = data.message_id.toString()
+  message.id = message.messageId = 'raw' in data ? data.raw.msgId : data.message_id.toString();
 
   // message content
   const chain = CQCode.parse(data.message)


### PR DESCRIPTION
在使用 [LLOnebot](https://github.com/LLOneBot/LLOneBot) 作为Onebot服务端的时候，messageId会传入异常的值，我已在原项目提交了issue，不知作者什么时候能修复，所以加了这个逻辑判断，让使用LLOnebot的用户也能正常获取到messageId（LLOnebot用户需在设置界面开启调试模式），且上报的消息中不含raw参数时会使用原获取方法