### PR TITLE
fix: getMessageList in private channels

### DIFF
--- a/src/bot/base.ts
+++ b/src/bot/base.ts
@@ -65,10 +65,10 @@ export class BaseBot<C extends Context = Context, T extends BaseBot.Config = Bas
       if (before) {
         const msg = await this.internal.getMsg(before)
         if (msg?.message_seq) {
-          list = (await this.internal.getFriendMsgHistory(userId, msg.message_seq)).messages
+          list = (await this.internal.getFriendMsgHistory(userId, msg.message_seq))
         }
       } else {
-        list = (await this.internal.getFriendMsgHistory(userId)).messages
+        list = (await this.internal.getFriendMsgHistory(userId))
       }
     } else {
       // 群聊频道使用 get_group_msg_history

--- a/src/types.ts
+++ b/src/types.ts
@@ -433,7 +433,7 @@ export interface Internal {
   getWordSlices(content: string): Promise<string[]>
   ocrImage(image: string): Promise<OcrResult>
   getGroupMsgHistory(group_id: id, message_seq?: number): Promise<{ messages: Message[] }>
-  getFriendMsgHistory(user_id: id, message_seq?: number, count?: number, reverseOrder?: boolean): Promise<{ messages: Message[] }>
+  getFriendMsgHistory(user_id: id, message_seq?: number, count?: number, reverseOrder?: boolean): Promise<Message[]>
   deleteFriend(user_id: id): Promise<void>
   deleteFriendAsync(user_id: id): Promise<void>
   deleteUnidirectionalFriend(user_id: id): Promise<void>


### PR DESCRIPTION
修复在私聊频道中调用bot.getMessageList时报错的bug

getFriendMsgHistory方法标注的类型错误，导致在getMessageList中获取私聊频道信息时多嵌套了一层messages