### PR TITLE
fix(ws): 修复 WebSocket 断开后 `_request is not a function` 及重连状态被覆盖

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export default OneBotBot
 declare module '@satorijs/core' {
   interface Session {
     onebot?: OneBot.Payload & OneBot.Internal
+    subsubtype?: string
   }
 }
 

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -1,4 +1,4 @@
-import { Adapter, Context, HTTP, Logger, Schema, Time, Universal } from 'koishi'
+import { Adapter, Context, Dict, HTTP, Logger, Schema, Time, Universal } from 'koishi'
 import { WebSocketLayer } from '@koishijs/plugin-server'
 import { OneBotBot } from './bot'
 import { dispatchSession, Response, TimeoutError } from './utils'
@@ -57,7 +57,7 @@ export class WsServer<C extends Context> extends Adapter<C, OneBotBot<C, OneBotB
       if (!bot) return socket.close(1008, 'invalid x-self-id')
 
       bot[kSocket] = socket
-      accept(socket, bot)
+      accept(socket as Universal.WebSocket, bot)
     })
 
     ctx.on('dispose', () => {
@@ -87,8 +87,70 @@ export namespace WsServer {
 let counter = 0
 const listeners: Record<number, (response: Response) => void> = {}
 
-export function accept<C extends Context>(socket: Universal.WebSocket, bot: OneBotBot<C, OneBotBot.BaseConfig & SharedConfig>) {
+interface PendingRequest {
+  reject: (error: Error) => void
+  dispose: () => void
+}
+
+export function accept<C extends Context>(socket: Universal.WebSocket, bot: OneBotBot<C, OneBotBot.Config>) {
+  const responseTimeout = 'responseTimeout' in bot.config ? bot.config.responseTimeout : Time.minute
+  const pending = new Map<number, PendingRequest>()
+  let closed = false
+
+  const request = (action: string, params: Dict): Promise<Response> => {
+    if (closed) return Promise.reject(new Error('OneBot WebSocket connection has closed'))
+    const data = { action, params, echo: ++counter }
+    return new Promise<Response>((resolve, reject) => {
+      // 超时后主动清理，避免 pending 和全局 listeners 一直残留
+      const dispose = bot.ctx.setTimeout(() => {
+        pending.delete(data.echo)
+        delete listeners[data.echo]
+        reject(new TimeoutError(params, action))
+      }, responseTimeout)
+      pending.set(data.echo, { reject, dispose })
+      listeners[data.echo] = (response) => {
+        pending.delete(data.echo)
+        dispose()
+        delete listeners[data.echo]
+        resolve(response)
+      }
+      try {
+        socket.send(JSON.stringify(data))
+      } catch (error) {
+        pending.delete(data.echo)
+        dispose()
+        delete listeners[data.echo]
+        reject(error)
+      }
+    })
+  }
+
+  let disposeContext: () => void = () => {}
+  const cleanup = () => {
+    if (closed) return
+    closed = true
+
+    // 断开时立即拒绝当前连接所有未完成的请求
+    const error = new Error('OneBot WebSocket connection has closed')
+    for (const [echo, pendingRequest] of pending) {
+      delete listeners[echo]
+      pendingRequest.dispose()
+      pendingRequest.reject(error)
+    }
+    pending.clear()
+
+    // 只清理仍属于当前连接的 _request，避免旧连接关闭时误删新连接的状态
+    if (bot.internal._request === request) {
+      bot.internal._request = () => Promise.reject(error)
+      // WsClient 的重连由基类管理，close 时不要覆盖其状态；反向 WS 没有基类重连，仍要置为离线
+      if (bot.config.protocol === 'ws-reverse') bot.offline()
+    }
+    disposeContext()
+  }
+  disposeContext = bot.ctx.on('dispose', cleanup)
+
   socket.addEventListener('message', (event) => {
+    if (closed) return
     let parsed: any
     const data = event.data.toString()
     try {
@@ -106,23 +168,8 @@ export function accept<C extends Context>(socket: Universal.WebSocket, bot: OneB
     }
   })
 
-  socket.addEventListener('close', () => {
-    delete bot.internal._request
-    bot.offline()
-  })
+  socket.addEventListener('close', cleanup)
 
-  bot.internal._request = (action, params) => {
-    const data = { action, params, echo: ++counter }
-    data.echo = ++counter
-    return new Promise((resolve, reject) => {
-      listeners[data.echo] = resolve
-      setTimeout(() => {
-        delete listeners[data.echo]
-        reject(new TimeoutError(params, action))
-      }, bot.config.responseTimeout)
-      socket.send(JSON.stringify(data))
-    })
-  }
-
+  bot.internal._request = request
   bot.initialize()
 }


### PR DESCRIPTION
### 问题说明

WebSocket 断开后，OneBot 适配器仍可能处理旧连接上已经开始的异步事件，例如 `adaptMessage()` 中获取回复消息。原实现会在 close 时直接 `delete bot.internal._request`，导致后续 API 调用报：

```text
TypeError: this._request is not a function
```

同时，正向 WS 的 close 处理器会调用 `bot.offline()`，可能把 `WsClientBase` 已设置好的 `RECONNECT` 状态覆盖成 `OFFLINE`，使基类重连定时器因 `getActive() === false` 直接停止。

### 修改内容

#### `src/ws.ts`

- 为每个 WebSocket 连接维护独立的 pending 请求表，断开时立即拒绝所有未完成请求，并清理全局 `listeners`。
- 关闭连接时不再直接 `delete bot.internal._request`，而是替换为返回拒绝 Promise 的函数，避免旧连接上的异步调用继续触发 TypeError。
- 仅在 `_request` 仍属于当前连接时才清理它，避免旧连接关闭时误删新连接的状态。
- 正向 WS `protocol === 'ws'` 不再调用 `bot.offline()`，把重连状态交给 `WsClientBase` 管理；反向 WS `protocol === 'ws-reverse'` 仍按原逻辑置为离线。
- 请求超时改用 `bot.ctx.setTimeout()`。
- 修复 `echo` 被重复递增两次的问题。

#### `src/index.ts`

- 补充 `Session.subsubtype` 类型声明，修复现有代码下的类型错误。

### 额外说明

我们在分析中还发现 `@satorijs/core` 的 `WsClientBase` 存在 `initial` 参数始终为 `true` 的问题，可能导致 `retryTimes` 耗尽后无法切换到 `retryLazy` 模式。